### PR TITLE
Add vim modelines.

### DIFF
--- a/tlm/constants.py
+++ b/tlm/constants.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  constants.py
 #  

--- a/tlm/elems_shared.py
+++ b/tlm/elems_shared.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  elems_shared.py
 #  

--- a/tlm/elems_spinup.py
+++ b/tlm/elems_spinup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  elems_spinup.py
 #  

--- a/tlm/elems_test.py
+++ b/tlm/elems_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  elems_test.py
 #  

--- a/tlm/fss_angle.py
+++ b/tlm/fss_angle.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  fss_angle.py
 #  

--- a/tlm/input.py
+++ b/tlm/input.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  io.py
 #  

--- a/tlm/layout.py
+++ b/tlm/layout.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  layout.py
 #  

--- a/tlm/lut.py
+++ b/tlm/lut.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  lut.py
 #  

--- a/tlm/net.py
+++ b/tlm/net.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  net.py
 #  

--- a/tlm/primitives.py
+++ b/tlm/primitives.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  primitives.py
 #  

--- a/tlm/realtime_graph.py
+++ b/tlm/realtime_graph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  realtime_graph.py
 #  

--- a/tlm/res.py
+++ b/tlm/res.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  res.py
 #  

--- a/tlm/server.py
+++ b/tlm/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  server.py
 #  

--- a/tlm/spin_rate.py
+++ b/tlm/spin_rate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  spin_rate.py
 #  

--- a/tlm/state.py
+++ b/tlm/state.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  state.py
 #  

--- a/tlm/tlm.py
+++ b/tlm/tlm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  tlm.py
 #  

--- a/tlm/tlm_graph.py
+++ b/tlm/tlm_graph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  tlm_graph.py
 #  

--- a/tlm/ui.py
+++ b/tlm/ui.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  ui.py
 #  

--- a/tlm/utils.py
+++ b/tlm/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# vim: noet ci pi sts=0 sw=4 ts=4 :
 #
 #  utils.py
 #  


### PR DESCRIPTION
Using tabs for indentation is a reasonable choice for python,
but not for bracket languages. As such my editor is incapable
of correct indentation without a modeline to enforce local style.
