### PR TITLE
Add a list action.

### DIFF
--- a/tlm/server.py
+++ b/tlm/server.py
@@ -223,12 +223,12 @@ class Server():
 				
 				try:
 					action				= msg['action'].lower()
-					data				= msg['data']
 					
 					response['action']	= action
 					response['seq']		= msg['seq']
 					
 					if action == "register":
+						data = msg['data']
 						for element_id in data:
 							element_state = self.element_state_manager.get_element_state(element_id, safe=False)
 							if element_state is None:
@@ -260,6 +260,7 @@ class Server():
 							
 							self.log("%s: Registered: %s" % (client_address, ", ".join([x['id'] for x in successful_elements])))
 					elif action == "unregister":
+						data = msg['data']
 						self.log("%s: Unregistering: %s" % (client_address, ", ".join(map(str, data))))
 						
 						registered_element_states = self._get_client_element_states(client)
@@ -306,6 +307,9 @@ class Server():
 						untracked_elements = self._untrack(element_states, client)
 						
 						self.log("%s: Unregistered: %s" % (client_address, ", ".join([x.get_element().id() for x in untracked_elements])))
+					elif action == "list":
+						successful_elements += self.element_state_manager.element_state_map.keys()
+						self.log("%s: Listing: %s" % (client_address, ", ".join(successful_elements)))
 					else:
 						res['error'] = "Action unrecognised: '%s'" % (msg['action'])
 				except Exception, e:

--- a/tlm/server.py
+++ b/tlm/server.py
@@ -309,7 +309,7 @@ class Server():
 						self.log("%s: Unregistered: %s" % (client_address, ", ".join([x.get_element().id() for x in untracked_elements])))
 					elif action == "list":
 						successful_elements += self.element_state_manager.element_state_map.keys()
-						self.log("%s: Listing: %s" % (client_address, ", ".join(successful_elements)))
+						self.log("%s: Listing requested" % str(client_address))
 					else:
 						res['error'] = "Action unrecognised: '%s'" % (msg['action'])
 				except Exception, e:


### PR DESCRIPTION
Move the data dereference into the two actions which need it
so we don't throw in the list method which doesn't.

This isn't ideal; we use the same template as the register
calls so the available elements are returned in a nested
'result' array.
